### PR TITLE
Update README.md to correct how signing keys are to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ composer require lcobucci/clock \
 
 ```php
 use Lcobucci\Clock\SystemClock;
+use Lcobucci\JWT\Signer\Key\InMemory;
 use Mezzio\Session\SessionMiddleware;
 use PSR7Sessions\Mezzio\Storageless\SessionPersistence;
 use PSR7Sessions\Storageless\Http\SessionMiddleware as PSR7SessionMiddleware;
 
 $app = \Mezzio\AppFactory::create();
 $app->pipe(PSR7SessionMiddleware::fromSymmetricKeyDefaults(
-    'OpcMuKmoxkhzW0Y1iESpjWwL/D3UBdDauJOe742BJ5Q=',
+    InMemory::plainText('OpcMuKmoxkhzW0Y1iESpjWwL/D3UBdDauJOe742BJ5Q='),
     1200
 ));
 $app->pipe(new SessionMiddleware(new SessionPersistence(new SystemClock())));
@@ -34,14 +35,15 @@ $app->pipe(new SessionMiddleware(new SessionPersistence(new SystemClock())));
 
 ```php
 use Lcobucci\Clock\SystemClock;
+use Lcobucci\JWT\Signer\Key\InMemory;
 use Mezzio\Session\SessionMiddleware;
 use PSR7Sessions\Mezzio\Storageless\SessionPersistence;
 use PSR7Sessions\Storageless\Http\SessionMiddleware as PSR7SessionMiddleware;
 
 $app = \Mezzio\AppFactory::create();
 $app->pipe(PSR7SessionMiddleware::fromSymmetricKeyDefaults(
-    file_get_contents('/path/to/private_key.pem'),
-    file_get_contents('/path/to/public_key.pem'),
+    InMemory::file('/path/to/private_key.pem'),
+    InMemory::file('/path/to/public_key.pem'),
     1200
 ));
 $app->pipe(new SessionMiddleware(new SessionPersistence(new SystemClock())));

--- a/test/Mezzio/Storageless/SessionPersistenceTest.php
+++ b/test/Mezzio/Storageless/SessionPersistenceTest.php
@@ -11,7 +11,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use PSR7Sessions\Mezzio\Storageless\SessionPersistence;
 use PSR7Sessions\Storageless\Http\SessionMiddleware;
 use PSR7Sessions\Storageless\Session\SessionInterface;
-use PSR7SessionsTest\Mezzio\Storageless\SessionThatIsIdentifierAware;
 use UnexpectedValueException;
 
 use function sprintf;

--- a/test/Mezzio/Storageless/SessionThatIsIdentifierAware.php
+++ b/test/Mezzio/Storageless/SessionThatIsIdentifierAware.php
@@ -7,4 +7,6 @@ namespace PSR7SessionsTest\Mezzio\Storageless;
 use Mezzio\Session\SessionIdentifierAwareInterface;
 use Mezzio\Session\SessionInterface;
 
-interface SessionThatIsIdentifierAware extends SessionInterface, SessionIdentifierAwareInterface {}
+interface SessionThatIsIdentifierAware extends SessionInterface, SessionIdentifierAwareInterface
+{
+}


### PR DESCRIPTION
psr7-sessions/storageless lib changed its middleware factory API of accepting signing keys. README example code follows these changes.